### PR TITLE
Print actual vs. expected when regexp check fails

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -64,7 +64,7 @@ function __checkRegExp(result, test, field, label) {
   var error;
 
   if (expect !== undefined && !actual.match(new RegExp(expect))) {
-    error = util.format('%s does not match expected regexp \'%s\'', label, expect);
+    error = util.format('%s: \'%s\' does not match expected regexp \'%s\'', label, actual, expect);
   }
 
   return error;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "command-line",
     "cli integration test"
   ],
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "http://github.com/cliffano/cmdt",
   "author": "Cliffano Subagio <blah@cliffano.com> (http://blog.cliffano.com)",
   "contributors": [

--- a/test/checker.js
+++ b/test/checker.js
@@ -37,7 +37,7 @@ buster.testCase('checker - _checkOutput', {
     var test   = { output: 'Foo Bar' };
     var errors = checker.check(result, test);
     assert.equals(errors.length, 1);
-    assert.equals(errors[0], 'Output does not match expected regexp \'Foo Bar\'');
+    assert.equals(errors[0], 'Output: \'Hello world\' does not match expected regexp \'Foo Bar\'');
   },
   'should return no error when there is no expectation': function () {
     var result = { output: 'Hello world' };

--- a/test/cmdt.js
+++ b/test/cmdt.js
@@ -237,7 +237,7 @@ buster.testCase('cmdt - _testCb', {
     cmdt._testCb(test, done)();
   },
   'should emit failure to reporter when there is an error': function (done) {
-    this.mockReporter.expects('emit').withExactArgs('failure', ['Output does not match expected regexp \'someotheroutput\''], { execId: '333-somefile2.yml', exitcode: 0, file: 'somefile2.yml', output: 'someotheroutput' }, { exitcode: 0, output: 'someoutput' });
+    this.mockReporter.expects('emit').withExactArgs('failure', ['Output: \'someoutput\' does not match expected regexp \'someotheroutput\''], { execId: '333-somefile2.yml', exitcode: 0, file: 'somefile2.yml', output: 'someotheroutput' }, { exitcode: 0, output: 'someoutput' });
 
     var test = { execId: '333-somefile2.yml', file: 'somefile2.yml', exitcode: 0, output: 'someotheroutput' };
 


### PR DESCRIPTION
Prior to this change cmdt did not print the the actual value of stdout
when a regexp expectation failed, only the expected value. That makes it
impossible to troubleshoot test failures on CI.